### PR TITLE
Allow system=java to prevent downloading a JDK

### DIFF
--- a/doc/preambles/shunit
+++ b/doc/preambles/shunit
@@ -1,0 +1,6 @@
+/// Preamble for running tests with tsk from working dir 2> /dev/null
+/*
+SETTINGS
+source 'TSK_BIN'
+run
+*/

--- a/test/lib/helpers.sh
+++ b/test/lib/helpers.sh
@@ -1,4 +1,5 @@
 export tsk_version="$(git describe --exact-match 2> /dev/null || git rev-parse HEAD)"
+export tsk_bin="$(pwd)/tsk"
 
 emulateTskDownload() {
   ln -fs "$(pwd)/boot-tsk" ~/.tsk/boot-tsk-${tsk_version}
@@ -7,17 +8,47 @@ emulateTskDownload() {
   ln -fs "$(pwd)/tsk" ~/.tsk/tsk-local
 }
 
+localJavaHome() {
+  systemJavaHome || coursierJavaHome
+}
+
+# Determine the java home from system java
+systemJavaHome() {
+  command -v java > /dev/null 2>&1 && java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home =' | sed 's/.*= //'
+}
+
+# When running system-java tests and the user/CI does not have a system java
+# we get a default one with coursier.
+coursierJavaHome() {
+  ( # Use a subshell to prevent poluting env 
+    unset JAVA_HOME
+    # Create an empty script just to source tsk utils
+    script_file="${SHUNIT_TMPDIR}/empty.sc"
+    touch "$script_file"
+    source "$tsk_bin" "$script_file"
+    rm "$script_file"
+    prepare_java 1>&2 # install default java via coursier
+    PATH="$(p_with_custom_java)" systemJavaHome
+  )
+}
+
+
 # Outputs tsk-tsk preamble from selected file (first argument)
-# with VERSION replaced with current version
-# and with SETTINGS replaced with given ones (second argument)
+# with the following replacements:
+#
+# TSK_BIN replaced with full path of local tsk script.
+# VERSION replaced with current version
+# SETTINGS replaced with given ones (second argument)
 #
 # All github links get replaced with raw.githubusercontent.com forms
 # (to not have to rely on every version be exposed at git.io)
 preamble() {
-  sed "s/VERSION/${tsk_version}/g
-       s/SETTINGS/${2}/g;" "./doc/preambles/${1}" | \
-       sed "s|git.io/boot-tsk-${tsk_version}|raw.githubusercontent.com/tsk-tsk/tsk-tsk/${tsk_version}/boot-tsk|g
-            s|git.io/boot-tsk-\\\$v|raw.githubusercontent.com/tsk-tsk/tsk-tsk/${tsk_version}/boot-tsk|g"
+  sed "s|TSK_BIN|${tsk_bin}|g;
+       s/VERSION/${tsk_version}/g;
+       s/SETTINGS/${2}/g;
+       s|git.io/boot-tsk-${tsk_version}|raw.githubusercontent.com/tsk-tsk/tsk-tsk/${tsk_version}/boot-tsk|g;
+       s|git.io/boot-tsk-\\\$v|raw.githubusercontent.com/tsk-tsk/tsk-tsk/${tsk_version}/boot-tsk|g" \
+      "./doc/preambles/${1}"
 }
 
 saveAsScript() {

--- a/test/system-java.sh
+++ b/test/system-java.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+testUsingSystemJavaShouldNotDownloadJVM() {
+  {
+    preamble shunit 'java_version=system'
+    echo 'object PieceOfCake extends App { println("ok") }'
+  } | saveAsScript "${wd}/Easy.scala"
+
+  ( # Using a sub-shell to keep these variables scoped
+    export JAVA_HOME="$javaHome"
+    export PATH="$javaHome/bin:$PATH"
+    export HOME="$homeDir"
+    export COURSIER_JVM_CACHE="$coursierJvms"
+    cd "$wd"
+    bash -c "${wd}/Easy.scala" > "${standard_output_file}" 2> "${standard_error_file}"
+
+    assertStandardOutputEquals "ok"
+    assertEquals "Should have installed coursier without jvm" "1" "$(ls -1 "$HOME"/.tsk/cs-*-jvmless | wc -l)"
+    assertEquals "Should not have download any jvm" "0" "$(ls -1 "$COURSIER_JVM_CACHE"/ | wc -l)"
+  )
+
+}
+
+oneTimeSetUp() {
+  javaHome="$(localJavaHome)"
+  coursierJvms="${SHUNIT_TMPDIR}/coursier-jvms"
+  homeDir="${SHUNIT_TMPDIR}/home"
+  outputDir="${SHUNIT_TMPDIR}/output"
+  standard_output_file="${outputDir}/stdout"
+  standard_error_file="${outputDir}/stderr"
+
+  mkdir -p "$coursierJvms" "$homeDir" "$outputDir"
+  wd="${SHUNIT_TMPDIR}"
+}
+
+tearDown() {
+  echo "This is contents of standard error"
+  echo "----------------------------------"
+  cat "${standard_error_file}"
+}
+
+. ./test/lib/helpers.sh
+[ -n "${ZSH_VERSION:-}" ] && SHUNIT_PARENT=$0
+. ./test/lib/shunit2

--- a/tsk
+++ b/tsk
@@ -47,6 +47,8 @@ verbose="${verbose:-just_progress}"
 coursier_version="${coursier_version:-v2.0.12}"
 
 # Version of Java Virtual Machine, necessary to launch Bloop and (after compilation) the script itself
+# A value of `system` prevents TSK from trying to download a JVM and expects an existing JVM to be available.
+# Once you have Coursier installed you can use `coursier java --available` to get a list of installable runtimes.
 java_version="${java_version:-8}"
 
 # Version of Java used at Alpine in order to bootstrap Coursier
@@ -176,10 +178,15 @@ all_sources_json_array() {
   echo "[ $(get_abs_sources | sed 's/\(.*\)/"\1",/g')
           \"$(get_abs_script_dir)/$(basename "${script_file}")\" ]"
 }
+
+
+os=$(uname)
 td=~/.tsk
+mkdir -p "$td" > /dev/null 2>&1 || (fatal_error "Directory '${td}' is required by script to be run.
+Make sure you have sufficient access rights and that no file with this name exists already."; exit 1)
 # work around https://github.com/coursier/coursier/issues/1856
 bloop_cmd="${td}/bloop-$(echo "${bloop_version}" | sed 's/:/_/g')"
-cs_binary="${td}/cs-${coursier_version}"
+cs_binary="${td}/cs-${coursier_version}$([[ "system" = "$java_version" ]] && echo "-jvmless" || echo "-$os")"
 cs_cmd="${cs_binary} ${COURSIER_OPTS:-}"
 get_sha_sum() {
   if command -v sha256sum > /dev/null 2>&1
@@ -190,11 +197,10 @@ get_sha_sum() {
   fi
 }
 p_with_custom_java() {
-  echo "$( ${cs_cmd} java-home --jvm "${java_version}" )/bin:${PATH}"
+  echo "$( ${cs_cmd} java-home -q --mode offline --jvm "${java_version}" )/bin:${PATH}"
 }
 download_as=$( command -v wget > /dev/null && echo "wget -O" || echo "curl -fLo" )
 module="$( basename "${script_file}" | sed 's/\.scala//g' )"
-os=$(uname)
 
 # bloop and coursier internals
 bloop_dir="${script_dir}/.bloop"
@@ -265,13 +271,18 @@ install_native_image_generator() {
 install_coursier() {
   [ -e "$cs_binary" ] && return 0;
   cs_url_prefix="https://github.com/coursier/coursier/releases/download/${coursier_version}"
-  case "${os}" in
-    "Linux")
+  case "${os}/java-${java_version}" in
+    *"/java-system")
+      # When using java_version=system, just download the smallest coursier shell without JVM.
+      cs_url="${cs_url_prefix}/coursier"
+      command -v java > /dev/null 2>&1 || (log_fatal "Using jvm-less coursier but no system java present. Please install java first"; return 1)
+      ;;
+    "Linux"*)
       case "$(ldd /bin/sh | awk '/libc/ {print $1}' | sed 's/-.*//g')" in
         "libc.musl")
           # Coursier isn't compiled against libc.musl yet (Alpine uses it), need to either have java already
           # or to have root permissions
-          if ! command -v java > /dev/null
+          if ! command -v java > /dev/null 2>&1
           then
             if [ "$(whoami)" = "root" ]
             then
@@ -285,11 +296,11 @@ install_coursier() {
         "libc.so.6")
           cs_url="${cs_url_prefix}/cs-x86_64-pc-linux";;
       esac;;
-    "Darwin")
+    "Darwin"*)
       cs_url="${cs_url_prefix}/cs-x86_64-apple-darwin";;
     *)
       cs_url="${cs_url_prefix}/coursier"
-      command -v java || (log_fatal "Unknown system: ${os} and no java present. Please install java first"; return 1)
+      command -v java > /dev/null 2>&1 || (log_fatal "Unknown system: ${os} and no java present. Please install java first"; return 1)
   esac
   echo "Installing Coursier" | log_as progress
   ${download_as} "$cs_binary" "$cs_url" 2>&1 | log_as progress
@@ -515,9 +526,13 @@ EOF
     )
 }
 
-prepare_for_running_with_bloop() {
+prepare_java() {
   install_coursier          || (log_fatal "Could not install Coursier"; return 1)
   install_java              || (log_fatal "Could not install Java Virtual Machine"; return 1)
+}
+
+prepare_for_running_with_bloop() {
+  prepare_java
   install_bloop             || (log_fatal "Could not install Bloop"; return 1)
   mkdir -p "${bloop_dir}"   || (log_fatal "Could not create .bloop directory"; return 1)
   generate_bloop_config     || (log_fatal "Could not generate Bloop configuration"; return 1)


### PR DESCRIPTION
Turns out coursier already interprets the `system` value
to reference the system installed java runtime.

So, for example if you execute:

`coursier java-home --jvm system`

It will try to find your current JAVA_HOME.

We now take advantage of this and if users specify the
`java_version=system` we will make sure they have an
existing `java` command already available.

Also, we will try to download the small jvm-less coursier
script, instead of downloading it with a jre which will save
a lot of bandwidth.

The test for this sets a custom COURSIER_JVM_CACHE variable
and makes sure it we wont download a jvm inside of it.