### PR TITLE
Prefer download bloop prebuilt if possible.

### DIFF
--- a/tsk
+++ b/tsk
@@ -178,7 +178,7 @@ all_sources_json_array() {
 }
 td=~/.tsk
 # work around https://github.com/coursier/coursier/issues/1856
-bloop_cmd="${td}/bloop-$(echo "${bloop_version}" | sed 's/:/_/g')"
+bloop_binary="${td}/bloop-$(echo "${bloop_version}" | sed 's/:/_/g')"
 cs_binary="${td}/cs-${coursier_version}"
 cs_cmd="${cs_binary} ${COURSIER_OPTS:-}"
 get_sha_sum() {
@@ -297,12 +297,23 @@ install_coursier() {
 }
 
 install_bloop() {
-  [ -e "${bloop_cmd}" ] && return 0;
+  [ -e "${bloop_binary}" ] && return 0;
   echo "Installing Bloop" | log_as progress
+  # First try to install bloop prebuilt binary (~4k) otherwise simply bootstrap (~30M) with coursier.
+  # The prebuilt binary is preferred since it will be faster since coursier bootstrapped binaries DO perform JVM startup.
+  (install_bloop_prebuilt || install_bloop_bootstrapped) 2>&1 | log_as progress
+}
+
+install_bloop_prebuilt() {
+  ${cs_cmd} install "bloop:$(echo "${bloop_version}" | sed 's/.*://g')" --only-prebuilt=true --install-dir "${td}" &&
+    mv "${td}/bloop" "${bloop_binary}"
+}
+
+install_bloop_bootstrapped() {
   # Normally we should install the latest stable like below, but it seems to have troubles at the time of writing it
-  # $cs_cmd bootstrap bloop --standalone -o "${bloop_cmd}"
+  # $cs_cmd bootstrap bloop --standalone -o "${bloop_binary}"
   PATH="$(p_with_custom_java)" ${cs_cmd} bootstrap \
-    "ch.epfl.scala:bloopgun_${bloop_version}" --standalone -o "${bloop_cmd}" 2>&1 | log_as progress
+    "ch.epfl.scala:bloopgun_${bloop_version}" --standalone -o "${bloop_binary}"
 }
 
 build_inputs() {
@@ -522,15 +533,11 @@ prepare_for_running_with_bloop() {
   mkdir -p "${bloop_dir}"   || (log_fatal "Could not create .bloop directory"; return 1)
   generate_bloop_config     || (log_fatal "Could not generate Bloop configuration"; return 1)
   grep -q "$(all_inputs_sha)" "${compilation_input_summary_file}" 2> /dev/null && return 0
-  PATH="$(p_with_custom_java)" ${cs_cmd} launch "ch.epfl.scala:bloopgun_${bloop_version}" \
-    --extra-jars "$( ${cs_cmd} fetch -p org.scala-lang.modules:scala-collection-compat_2.12:2.4.2)" -- about \
-    > /dev/null 2>&1 || (fatal_error "Error while pre-warming Bloop"; return 1)
+  "${bloop_binary}" about > /dev/null 2>&1 || \
+    (fatal_error "Error while pre-warming Bloop"; return 1)
   (
     (
-      PATH="$(p_with_custom_java)" ${cs_cmd} launch "ch.epfl.scala:bloopgun_${bloop_version}" \
-        --extra-jars "$( ${cs_cmd} fetch -p org.scala-lang.modules:scala-collection-compat_2.12:2.4.2)" -- \
-        compile --config-dir "${script_dir}/.bloop" "${module}" \
-        2>&1 | log_as progress
+      "${bloop_binary}" compile --config-dir "${script_dir}/.bloop" "${module}" 2>&1 | log_as progress
     ) && (all_inputs_sha > "${compilation_input_summary_file}")
   ) || (fatal_error "Error while compiling with Bloop"; return 1)
 }


### PR DESCRIPTION
Binaries generated by `coursier bootstrap` are intended to launch
generic java apps, and thus include a very tiny java-class that
runs the main app. However bloop already publishes a native binary
that is much more smaller and faster to boot.

This will reduce the percieved execution time when running tsk scripts.